### PR TITLE
[*] Updated lib manager to return libs intances

### DIFF
--- a/Src/Core/LibManager.cpp
+++ b/Src/Core/LibManager.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #include <dlfcn.h>
 }
 
-LibManager::LibManager(std::string &libPath)
+LibManager::LibManager(std::string libPath)
 {
     _libsHandle.emplace(libPath, nullptr);
 }
@@ -23,7 +23,7 @@ LibManager::LibManager(std::vector<std::string> libPaths)
     }
 }
 
-void *LibManager::openLib(std::string &libPath)
+void *LibManager::openLib(std::string libPath)
 {
     auto it = _libsHandle.find(libPath);
 
@@ -38,7 +38,26 @@ void *LibManager::openLib(std::string &libPath)
     return (it->second);
 }
 
-void LibManager::closeLib(std::string &libPath)
+IGame *LibManager::openGame(std::string libPath)
+{
+    void *libHandle = openLib(libPath);
+    IGame *(*createGame)();
+
+    createGame = (IGame *(*)(void))dlsym(libHandle, "createGame");
+    return (createGame());
+}
+
+template <typename T>
+IGraph<T> *LibManager::openGraph(std::string libPath)
+{
+    void *libHandle = openLib(libPath);
+    IGraph<T> *(*createGraph)();
+
+    createGraph = (IGraph<T> *(*)(void))dlsym(libHandle, "createGraph");
+    return (createGraph());
+}
+
+void LibManager::closeLib(std::string libPath)
 {
     auto it = _libsHandle.find(libPath);
 
@@ -49,22 +68,4 @@ void LibManager::closeLib(std::string &libPath)
         it->second = nullptr;
     } else
         throw LibraryEX("Library already closed", Logger::CRITICAL);
-}
-
-void *LibManager::getSymbol(void *libHandle, std::string &symbolName)
-{
-    void *symbol = dlsym(libHandle, symbolName.c_str());
-
-    if (symbol == nullptr)
-        throw LibraryEX(dlerror(), Logger::CRITICAL);
-    return (symbol);
-}
-
-void *LibManager::getSymbol(std::string &libPath, std::string &symbolName)
-{
-    auto it = _libsHandle.find(libPath);
-
-    if (it == _libsHandle.end())
-        throw LibraryEX("Library not found", Logger::CRITICAL);
-    return (getSymbol(it->second, symbolName));
 }

--- a/Src/Core/LibManager.hpp
+++ b/Src/Core/LibManager.hpp
@@ -11,6 +11,8 @@
 #define ARCADE_LIBMANAGER_HPP
 
 #include "Exception.hpp"
+#include "IGame.hpp"
+#include "IGraph.hpp"
 #include <map>
 #include <string>
 #include <vector>
@@ -23,7 +25,7 @@ class LibManager {
 
         /// \brief Creating a factory with a path to a library
         /// \param path Path to the game library
-        LibManager(std::string &libPath);
+        LibManager(std::string libPath);
 
         /// \brief Creating a factory with multiple paths to libraries
         /// \param libPaths Paths to the game libraries
@@ -38,35 +40,35 @@ class LibManager {
         /// \brief Destructor
         ~LibManager() = default;
 
-        /// \brief Opens a shared library and returns a pointer to the handle
+        /// \brief Opens a shared library, calls it's lib entrypoint and returns a pointer to a game instance
         /// \param libPath Path to the library
-        /// \return A pointer to the handle
-        /// \note The handle is not closed by the destructor
-        /// \warning Not closing the handle will lead to <b>Undefined Behaviour</b>
-        /// \throw LibraryException if the library cannot be opened
-        void *openLib(std::string &libPath);
+        /// \return A pointer to a game instance
+        IGame *openGame(std::string libPath);
+
+        /// \brief Opens a shared library, calls it's lib entrypoint and returns a pointer to a graph instance
+        /// \param libPath Path to the library
+        /// \return A pointer to a graph instance
+        template <typename T>
+        IGraph<T> *openGraph(std::string libPath);
 
         /// \brief Closes a shared library
         /// \param libPath Path to the library
         /// \warning Not using this method after opening a library will lead to <b>Undefined Behaviour</b>
         /// \warning Using this method before opening a library will lead to <b>Undefined Behaviour</b>
         /// \throw LibraryException if the library cannot be closed
-        void closeLib(std::string &libPath);
-
-        /// \brief Loads a symbol from a shared library
-        /// \param libHandle A pointer to the handle
-        /// \param symbolName Name of the symbol to load
-        /// \return A pointer to the symbol
-        /// \warning Using this method before opening a library will lead to <b>Undefined Behaviour</b>
-        /// \throw LibraryException if the symbol cannot be loaded
-        void *getSymbol(void *libHandle, std::string &symbolName);
-
-        /// \overload void *getSymbol(void *libHandle, std::string &symbolName)
-        void *getSymbol(std::string &libPath, std::string &symbolName);
+        void closeLib(std::string libPath);
 
     private:
         ///\note Map of the libraries' handles represented like so {libPath, libHandle}
         std::map<std::string, void *> _libsHandle;
+
+        /// \brief Opens a shared library and returns a pointer to the handle
+        /// \param libPath Path to the library
+        /// \return A pointer to the handle
+        /// \note The handle is not closed by the destructor
+        /// \warning Not closing the handle will lead to <b>Undefined Behaviour</b>
+        /// \throw LibraryException if the library cannot be opened
+        void *openLib(std::string libPath);
 };
 
 


### PR DESCRIPTION
LibManager now has 2 new public methods:
```c++
        /// \brief Opens a shared library, calls it's lib entrypoint and returns a pointer to a game instance
        /// \param libPath Path to the library
        /// \return A pointer to a game instance
        IGame *openGame(std::string libPath);

        /// \brief Opens a shared library, calls it's lib entrypoint and returns a pointer to a graph instance
        /// \param libPath Path to the library
        /// \return A pointer to a graph instance
        template <typename T>
        IGraph<T> *openGraph(std::string libPath);
```
calling them will open the desired Graphical or Game lib and retrieve a new Instance of a IGame / IGraph class
Fixes #70 